### PR TITLE
Increase minimum block confirmation to 2

### DIFF
--- a/src/Koyn.cpp
+++ b/src/Koyn.cpp
@@ -1256,7 +1256,7 @@ void KoynClass::processInput(String key,String value)
 					{
 						if(incomingTx[i].isUsed()&&incomingTx[i].inBlock())
 						{
-							if(isTransactionCallbackAssigned && incomingTx[i].getConfirmations()>0 && incomingTx[i].getConfirmations()<REMOVE_CONFIRMED_TRANSACTION_AFTER)
+							if(isTransactionCallbackAssigned && incomingTx[i].getConfirmations()>1 && incomingTx[i].getConfirmations()<REMOVE_CONFIRMED_TRANSACTION_AFTER)
 							{
 								#if defined(ENABLE_DEBUG_MESSAGES)
 								Serial.print(F("Block Difference "));
@@ -1278,7 +1278,7 @@ void KoynClass::processInput(String key,String value)
 				{
 					if(incomingTx[i].isUsed()&&incomingTx[i].inBlock())
 					{
-						if(isTransactionCallbackAssigned && incomingTx[i].getConfirmations()>0 && incomingTx[i].getConfirmations()<REMOVE_CONFIRMED_TRANSACTION_AFTER)
+						if(isTransactionCallbackAssigned && incomingTx[i].getConfirmations()>1 && incomingTx[i].getConfirmations()<REMOVE_CONFIRMED_TRANSACTION_AFTER)
 						{
 							#if defined(ENABLE_DEBUG_MESSAGES)
 							Serial.print(F("Block Difference "));


### PR DESCRIPTION
(Un)intentional blockchain reorgs are fairly common after 1 confirmation and can cause orphaned blocks and potentially double spending.
Currently, Koyn accepts 1 confirmation as a minimum condition to confirm payments. This is will cause problems when reorgs happen. In this PR, I increased the minimum required confirmations to 2, following recommendations of: https://bitcoin.org/en/developer-guide#verifying-payment

According to Bitcoin.org Developer Guide:

> 1 confirmation: The transaction is included in the latest block and double-spend risk decreases dramatically. Transactions which pay sufficient transaction fees need 10 minutes on average to receive one confirmation. However, the most recent block gets replaced fairly often by accident, so a double spend is still a real possibility.
> 
> 2 confirmations: The most recent block was chained to the block which includes the transaction. As of March 2014, two block replacements were exceedingly rare, and a two block replacement attack was impractical without expensive mining equipment.
