### PR TITLE
Update ESP8266 FQBN in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   global:
     - ARDUINO_VERSION="1.8.5"
   matrix:
-    - BOARD="esp8266:esp8266:generic" FLAGS=':CpuFrequency=80,ResetMethod=ck,CrystalFreq=26,FlashFreq=40,FlashMode=qio,FlashSize=512K0'
+    - BOARD="esp8266:esp8266:generic" FLAGS=':xtal=80,ResetMethod=ck,CrystalFreq=26,FlashFreq=40,FlashMode=qio,eesz=512K'
     - BOARD="esp32:esp32:esp32"       FLAGS=''
 
 before_install:


### PR DESCRIPTION
Some of the menu IDs for the ESP8266 boards were recently changed (https://github.com/esp8266/Arduino/issues/5572), which caused compilation in the Travis CI build to fail with "Invalid option for board" error.