### PR TITLE
Correct invalid keywords.txt KEYWORD_TOKENTYPE

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -34,10 +34,10 @@ getUnconfirmedBalance	KEYWORD2		RESERVED_WORD
 getInput	KEYWORD2		RESERVED_WORD
 getOutput	KEYWORD2		RESERVED_WORD
 getOutputAmount	KEYWORD2		RESERVED_WORD
-getInputsCount	KEYOWRD2
+getInputsCount	KEYWORD2
 getOutputsCount	KEYWORD2		RESERVED_WORD
 getHash	KEYWORD2		RESERVED_WORD
-getBlockNumber	KEYWROD2
+getBlockNumber	KEYWORD2
 getConfirmations	KEYWORD2		RESERVED_WORD
 #######################################
 # Structures and Classes (KEYWORD3)


### PR DESCRIPTION
Use of an invalid `KEYWORD_TOKENTYPE` value in keywords.txt causes the keyword to be colored by the default `editor.function.style` (as used by `KEYWORD2`, `KEYWORD3`, `LITERAL2`) in Arduino IDE 1.6.5 and newer. On Arduino IDE 1.6.4 and older this will cause the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype